### PR TITLE
feat: support trace method request

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "superagent": "^9.0.1"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.17.1",
+    "@arethetypeswrong/cli": "^0.17.3",
+    "@eggjs/bin": "7",
     "@eggjs/tsconfig": "1",
     "@types/body-parser": "^1.19.5",
     "@types/cookie-parser": "^1.4.8",
@@ -37,7 +38,6 @@
     "@types/node": "22",
     "body-parser": "^1.20.3",
     "cookie-parser": "^1.4.6",
-    "egg-bin": "6",
     "eslint": "8",
     "eslint-config-egg": "14",
     "express": "^4.18.2",

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -83,6 +83,9 @@ export class TestAgent extends Agent {
   options(url: string) {
     return this._testRequest('options', url);
   }
+  trace(url: string) {
+    return this._testRequest('trace', url);
+  }
 }
 
 // allow keep use by `agent()`

--- a/src/request.ts
+++ b/src/request.ts
@@ -56,4 +56,7 @@ export class Request {
   options(url: string) {
     return this._testRequest('options', url);
   }
+  trace(url: string) {
+    return this._testRequest('trace', url);
+  }
 }

--- a/test/supertest.test.ts
+++ b/test/supertest.test.ts
@@ -204,6 +204,18 @@ describe('request(app)', function() {
       .expect('Hello', done);
   });
 
+  it('should work on trace method', function(done) {
+    const app = express();
+
+    app.trace('/', function(_req, res) {
+      res.end('Hello');
+    });
+
+    request(app)
+      .trace('/')
+      .expect('Hello', done);
+  });
+
   it('should default redirects to 0', function(done) {
     const app = express();
 
@@ -1078,6 +1090,11 @@ describe('request.agent(app)', function() {
     res.send();
   });
 
+  app.trace('/', function(_req, res) {
+    res.cookie('cookie', 'hey');
+    res.send('trace method');
+  });
+
   app.get('/return_cookies', function(req, res) {
     if (req.cookies.cookie) res.send(req.cookies.cookie);
     else res.send(':(');
@@ -1104,6 +1121,12 @@ describe('request.agent(app)', function() {
     agent
       .get('/return_headers')
       .expect('hey', done);
+  });
+
+  it('should trace method work', function(done) {
+    agent
+      .trace('/')
+      .expect('trace method', done);
   });
 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for HTTP TRACE method in the testing framework
	- Expanded request handling capabilities for TRACE requests

- **Dependency Updates**
	- Updated `@arethetypeswrong/cli` to version `^0.17.3`
	- Added `@eggjs/bin` version `7`
	- Removed `egg-bin` version `6`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->